### PR TITLE
Added a quick table attributes test

### DIFF
--- a/src/ElementMap.php
+++ b/src/ElementMap.php
@@ -9,6 +9,13 @@ namespace charliedev\elementmap;
 use Craft;
 use craft\base\Plugin;
 
+// NOTE: Added the following to support custom Table Attributes
+use craft\base\Element;
+use craft\elements\Entry;
+use craft\events\RegisterElementTableAttributesEvent;
+use craft\events\SetElementTableAttributeHtmlEvent;
+use yii\base\Event;
+
 /**
  * The main Craft plugin class.
  */
@@ -31,6 +38,23 @@ class ElementMap extends Plugin
 		Craft::$app->getView()->hook('cp.categories.edit.details', [$this, 'renderCategoryElementMap']);
 		Craft::$app->getView()->hook('cp.users.edit.details', [$this, 'renderUserElementMap']);
 		Craft::$app->getView()->hook('cp.commerce.product.edit.details', [$this, 'renderProductElementMap']);
+
+    // NOTE: Added the following events to support custom Table Attributes
+    Event::on(Entry::class, Element::EVENT_REGISTER_TABLE_ATTRIBUTES, function(RegisterElementTableAttributesEvent $event) {
+      $event->tableAttributes['elementMap'] = ['label' => 'In Use On'];
+    });
+
+    Event::on(Entry::class, Element::EVENT_SET_TABLE_ATTRIBUTE_HTML, function(SetElementTableAttributeHtmlEvent $event) {
+      if ($event->attribute === 'elementMap') {
+        /** @var Entry $entry */
+        $entry = $event->sender;
+
+        $event->html = $this->renderer->render($entry->id, $entry->site->id, true);
+
+        // Prevent other event listeners from getting invoked
+        $event->handled = true;
+      }
+    });
 	}
 
 	/**

--- a/src/services/Renderer.php
+++ b/src/services/Renderer.php
@@ -28,13 +28,18 @@ class Renderer extends Component
 	 * @param int $elementid The ID of the element to render the map relative to.
 	 * @param int $siteid The ID of the site that relations should be determined from.
 	 */
-	public function render(int $elementid, int $siteid)
+  // NOTE: Added $tableview argument to render alternate template in entries view
+	public function render(int $elementid, int $siteid, $tableview = false)
 	{
 		// Gather up necessary structure data to render the element map with.
 		$results = $this->getElementMap($elementid, $siteid);
 
 		// Render the actual element map.
-		return Craft::$app->view->renderTemplate('element-map/_map', ['map' => $results]);
+    if ($tableview) {
+      return Craft::$app->view->renderTemplate('element-map/_map-table_view', ['map' => $results]);
+    } else {
+      return Craft::$app->view->renderTemplate('element-map/_map', ['map' => $results]);
+    }
 	}
 
 	/**

--- a/src/templates/_map-table_view.html
+++ b/src/templates/_map-table_view.html
@@ -1,0 +1,20 @@
+{%- import _self as macros -%}
+
+{%- do view.registerAssetBundle("charliedev\\elementmap\\assets\\ElementMapBundle") -%}
+
+<div class="meta element-map">
+
+	<div class="map">
+		<ul>
+			{% for element in map.incoming %}
+				<li>
+          {# NOTE: Link should also link to users' current site #}
+					<a target="_blank" href="{{ element.url }}" data-id="{{ element.id }}" data-editable><span class="icon icon-mask">{{ svg(element.icon) }}</span>{{ element.title }}</a>
+				</li>
+			{% endfor %}
+			{% if map.incoming | length == 0 %}
+			{% endif %}
+		</ul>
+	</div>
+
+</div>


### PR DESCRIPTION
This is just a super basic test and I didn't implement anything in a permanent way, but it seems to be working.

Originally, I thought a count should suffice, and added an issue (#6). Having a scannable, linkable list of places where my entries are referenced proved to be much more useful.

Notes:
- The label "In Use On" should probably be made editable via simple settings
- Links to related entries should probably keep the user in the same site that they're viewing entries from (seems to always link to the default site currently)